### PR TITLE
Fix iconset path WindowsError

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ what it believes are n new images, where each new image is a discrete
 character found within the original captcha.
 
 This work is a derivation of an original work by bboyte01@gmail.com,
-http://www.wausita.com/captcha/.
+http://www.boyter.org/decoding-captchas/.
 
 ## Example
 

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
         ],
     description="Basic Captcha Cracker",
     long_description=open(os.path.join(os.path.dirname(__file__), 'README.md')).read(),
+    include_package_data=True
 )


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "scripts\decaptcha", line 6, in <module>
    from decaptcha import crack
  File "C:\Python27\lib\site-packages\decaptcha-0.0.1-py2.7.egg\decaptcha\crack.py", line 25, in <module>
    IMAGESET = build_imgset()
  File "C:\Python27\lib\site-packages\decaptcha-0.0.1-py2.7.egg\decaptcha\util.py", line 28, in build_imgset
    for img in os.listdir('%s/iconset/%s/' % (APP_PATH, letter)):
WindowsError: [Error 3] The system cannot find the path specified: 'C:\\Python27\\lib\\site-packages\\decaptcha-0.0.1-py2.7.egg\\decaptcha/iconset/0/*.*'
```